### PR TITLE
feat: 引入多排行榜机制

### DIFF
--- a/platform/blueprints/ranking.py
+++ b/platform/blueprints/ranking.py
@@ -27,12 +27,17 @@ ranking_bp = Blueprint("ranking", __name__)
 def show_ranking():
     """显示排行榜页面"""
     # 获取排行榜类型
-    sort_by = request.args.get("sort_by", "score")
-    limit = request.args.get("limit", 100, type=int)  # 添加分页或限制参数
-    min_games = request.args.get("min_games", 1, type=int)  # 添加最小场次参数
+    sort_by = request.args.get(
+        "sort_by", "score"
+    )  # sort_by 当前未实际用于排序逻辑，因为 get_leaderboard 默认按 elo 排序
+    limit = request.args.get("limit", 100, type=int)
+    min_games = request.args.get("min_games", 1, type=int)
+    ranking_id = request.args.get("ranking_id", 0, type=int)  # 新增 ranking_id 参数
 
-    # 获取排行榜数据 - get_leaderboard 默认按 score 排序
-    leaderboard_data = get_leaderboard(limit=limit, min_games_played=min_games)
+    # 获取排行榜数据
+    leaderboard_data = get_leaderboard(
+        ranking_id=ranking_id, limit=limit, min_games_played=min_games
+    )
 
     ranking_items = []
     for idx, data in enumerate(leaderboard_data):
@@ -55,6 +60,7 @@ def show_ranking():
         "ranking.html",
         ranking_items=ranking_items,
         sort_by=sort_by,
+        current_ranking_id=ranking_id,  # 将 ranking_id 传递给模板
     )
 
 
@@ -62,12 +68,15 @@ def show_ranking():
 def get_ranking_data():
     """获取排行榜数据（API）"""
     # 获取排序类型
-    sort_by = request.args.get("sort_by", "score")
+    sort_by = request.args.get("sort_by", "score")  # sort_by 当前未实际用于排序逻辑
     limit = request.args.get("limit", 100, type=int)
     min_games = request.args.get("min_games", 1, type=int)
+    ranking_id = request.args.get("ranking_id", 0, type=int)  # 新增 ranking_id 参数
 
-    # 获取排行榜数据 - get_leaderboard 默认按 score 排序
-    leaderboard_data = get_leaderboard(limit=limit, min_games_played=min_games)
+    # 获取排行榜数据
+    leaderboard_data = get_leaderboard(
+        ranking_id=ranking_id, limit=limit, min_games_played=min_games
+    )
 
     ranking_list = []
     for idx, data in enumerate(leaderboard_data):
@@ -102,8 +111,10 @@ def get_user_stats(user_id):
     if not user:
         return jsonify({"success": False, "message": "用户不存在"})
 
+    ranking_id = request.args.get("ranking_id", 0, type=int)  # 新增 ranking_id 参数
+
     # 使用 get_game_stats_by_user_id 获取用户统计数据
-    stat = get_game_stats_by_user_id(user_id)
+    stat = get_game_stats_by_user_id(user_id, ranking_id=ranking_id)  # 传递 ranking_id
     if not stat:
         # 如果没有统计数据，返回成功但 stats 为空
         return jsonify(

--- a/platform/database/action.py
+++ b/platform/database/action.py
@@ -144,7 +144,7 @@ def create_user(username, email, password):
         user.set_password(password)  # 使用模型方法设置密码哈希
 
         # 为新用户创建游戏统计记录，即使他们还没玩过游戏
-        game_stats = GameStats(user=user)  # 建立关系
+        game_stats = GameStats(user_id=user.id, ranking_id=0)  # 显式设置 ranking_id
 
         db.session.add(user)
         db.session.add(game_stats)  # 添加统计记录
@@ -452,46 +452,56 @@ def get_ai_code_path_full(ai_code_id):
 # 游戏统计 (GameStats) CRUD 操作
 
 
-def get_game_stats_by_user_id(user_id):
+def get_game_stats_by_user_id(user_id, ranking_id=0):
     """
-    根据用户ID获取游戏统计记录。
+    根据用户ID和排行榜ID获取游戏统计记录。
 
     参数:
         user_id (str): 用户ID。
+        ranking_id (int): 排行榜ID。
 
     返回:
         GameStats: 游戏统计对象，不存在则返回None。
     """
     try:
-        return GameStats.query.filter_by(user_id=user_id).first()
+        return GameStats.query.filter_by(user_id=user_id, ranking_id=ranking_id).first()
     except Exception as e:
-        logger.error(f"获取用户 {user_id} 的游戏统计失败: {e}", exc_info=True)
+        logger.error(
+            f"获取用户 {user_id} 在排行榜 {ranking_id} 的游戏统计失败: {e}",
+            exc_info=True,
+        )
         return None
 
 
-def create_game_stats(user_id):
+def create_game_stats(user_id, ranking_id=0):
     """
-    为指定用户创建游戏统计记录 (如果在用户创建时没有自动创建)。
+    为指定用户在特定排行榜创建游戏统计记录。
 
     参数:
         user_id (str): 用户ID。
+        ranking_id (int): 排行榜ID。
 
     返回:
         GameStats: 创建成功的统计对象，失败或已存在则返回None。
     """
     try:
-        existing_stats = get_game_stats_by_user_id(user_id)
+        existing_stats = get_game_stats_by_user_id(user_id, ranking_id)
         if existing_stats:
-            logger.warning(f"用户 {user_id} 的游戏统计已存在，无需重复创建。")
+            logger.warning(
+                f"用户 {user_id} 在排行榜 {ranking_id} 的游戏统计已存在，无需重复创建。"
+            )
             return None
 
-        stats = GameStats(user_id=user_id)
+        stats = GameStats(user_id=user_id, ranking_id=ranking_id)
         if safe_add(stats):
-            logger.info(f"为用户 {user_id} 创建游戏统计成功。")
+            logger.info(f"为用户 {user_id} 在排行榜 {ranking_id} 创建游戏统计成功。")
             return stats
         return None
     except Exception as e:
-        logger.error(f"创建用户 {user_id} 的游戏统计失败: {e}", exc_info=True)
+        logger.error(
+            f"创建用户 {user_id} 在排行榜 {ranking_id} 的游戏统计失败: {e}",
+            exc_info=True,
+        )
         db.session.rollback()
         return None
 
@@ -523,11 +533,12 @@ def update_game_stats(stats, **kwargs):
         return False
 
 
-def get_leaderboard(limit=100, min_games_played=1):
+def get_leaderboard(ranking_id=0, limit=100, min_games_played=1):
     """
-    获取游戏排行榜。
+    获取指定排行榜的游戏排行榜。
 
     参数:
+        ranking_id (int): 排行榜ID。
         limit (int): 返回数量限制。
         min_games_played (int): 玩家至少参与的游戏场次。
 
@@ -538,7 +549,10 @@ def get_leaderboard(limit=100, min_games_played=1):
         leaderboard_data = (
             db.session.query(GameStats, User.username)
             .join(User, GameStats.user_id == User.id)
-            .filter(GameStats.games_played >= min_games_played)
+            .filter(
+                GameStats.ranking_id == ranking_id,
+                GameStats.games_played >= min_games_played,
+            )
             .order_by(GameStats.elo_score.desc())
             .limit(limit)
             .all()
@@ -564,16 +578,18 @@ def get_leaderboard(limit=100, min_games_played=1):
 # 对战 (Battle) 及 对战参与者 (BattlePlayer) CRUD 操作
 
 
-def create_battle(participant_data_list, status="waiting", section=0, game_data=None):
+def create_battle(
+    participant_data_list, ranking_id=0, status="waiting", game_data=None
+):
     """
     创建对战记录及关联的参与者记录。
 
     参数:
         participant_data_list (list): 参与者数据列表，每个元素应为字典，
-                                      至少包含 'user_id' 和 'ai_code_id'。 # <--- 修改文档注释
-                                      示例: [{'user_id': '...', 'ai_code_id': '...'}, ...] # <--- 修改文档注释
+                                      至少包含 'user_id' 和 'ai_code_id'。
+                                      示例: [{'user_id': '...', 'ai_code_id': '...'}, ...]
+        ranking_id (int): 对战所属的排行榜ID。默认为0。
         status (str): 初始状态 (e.g., 'waiting', 'playing'). 默认为 'waiting'.
-        section (int): 分区类型：0=普通对局，1=预选赛，2=决赛，等. 默认为 0.
         game_data (dict, optional): 游戏初始数据。
 
     返回:
@@ -605,7 +621,7 @@ def create_battle(participant_data_list, status="waiting", section=0, game_data=
 
         battle = Battle(
             status=status,
-            section=section,  # 使用传入的分区类型
+            ranking_id=ranking_id,
             created_at=datetime.datetime.now(),
             # started_at 在对战真正开始时设置
             # results 在对战结束时设置
@@ -617,7 +633,7 @@ def create_battle(participant_data_list, status="waiting", section=0, game_data=
         battle_players = []
         for i, data in enumerate(participant_data_list):
             # 获取玩家当前的ELO作为 initial_elo 快照
-            user_stats = get_game_stats_by_user_id(data["user_id"])
+            user_stats = get_game_stats_by_user_id(data["user_id"], ranking_id)
             initial_elo = (
                 user_stats.elo_score if user_stats else 1200
             )  # 默认或从 GameStats 获取
@@ -757,6 +773,7 @@ def process_battle_results_and_update_stats(battle_id, results_data):
     1. 更准确地识别玩家错误
     2. 基于错误类型和方法实现差异化的ELO惩罚
     3. 提供更详细的日志记录
+    4. 支持多排行榜 (ranking_id)
 
     参数:
         battle_id (str): 对战的唯一标识符
@@ -786,6 +803,8 @@ def process_battle_results_and_update_stats(battle_id, results_data):
         if not battle:
             logger.error(f"[Battle {battle_id}] 对战记录不存在")
             return False
+
+        battle_ranking_id = battle.ranking_id  # 获取对战的排行榜ID
 
         if battle.status == "completed":
             logger.info(f"[Battle {battle_id}] 对战已处理，跳过重复操作")
@@ -1028,14 +1047,17 @@ def process_battle_results_and_update_stats(battle_id, results_data):
         user_stats_map = {
             stats.user_id: stats
             for stats in GameStats.query.filter(
-                GameStats.user_id.in_(involved_user_ids)
+                GameStats.user_id.in_(involved_user_ids),
+                GameStats.ranking_id == battle_ranking_id,  # 使用对战的排行榜ID
             ).all()
         }
 
         # 创建缺失的统计记录
         for user_id in involved_user_ids:
             if user_id not in user_stats_map:
-                new_stats = create_game_stats(user_id)
+                new_stats = create_game_stats(
+                    user_id, battle_ranking_id
+                )  # 使用对战的排行榜ID
                 if new_stats:
                     user_stats_map[user_id] = new_stats
                     db.session.add(new_stats)
@@ -1362,6 +1384,7 @@ def handle_cancelled_battle_stats(battle_id):
     1. 不计入玩家游戏统计
     2. 或标记为"取消"而非输赢
     3. 或在特定情况下给予部分ELO补偿
+    4. 支持多排行榜 (ranking_id)
 
     参数:
         battle_id (str): 已取消对战的ID。
@@ -1374,6 +1397,8 @@ def handle_cancelled_battle_stats(battle_id):
         if not battle:
             logger.error(f"处理已取消对战统计失败: 对战 {battle_id} 不存在")
             return False
+
+        battle_ranking_id = battle.ranking_id  # 获取对战的排行榜ID
 
         if battle.status != "cancelled":
             logger.warning(f"对战 {battle_id} 不是已取消状态，无法处理取消统计")
@@ -1421,7 +1446,9 @@ def handle_cancelled_battle_stats(battle_id):
             # 例如：系统故障导致的取消不计入玩家的游戏场次
             if not is_system_error:
                 # 获取用户统计
-                stats = get_game_stats_by_user_id(bp.user_id)
+                stats = get_game_stats_by_user_id(
+                    bp.user_id, battle_ranking_id
+                )  # 使用对战的排行榜ID
                 if stats:
                     # 更新取消的对战计数（假设模型中有canceled_games字段）
                     # 如果模型中没有，可以添加，或者选择不记录

--- a/platform/templates/ranking.html
+++ b/platform/templates/ranking.html
@@ -4,13 +4,28 @@
 {% endblock title %}
 {% block content %}
     <div class="container mt-4">
-        <h2 class="mb-4">玩家排行榜</h2>
-        <!-- 可以添加排序选项 -->
-        <!-- <div class="mb-3">
-      <a href="{{ url_for('ranking.show_ranking', sort_by='score') }}" class="btn btn-sm {% if sort_by == 'score' %}btn-primary{% else %}btn-outline-primary{% endif %}">按分数排序</a>
-      <a href="{{ url_for('ranking.show_ranking', sort_by='wins') }}" class="btn btn-sm {% if sort_by == 'wins' %}btn-primary{% else %}btn-outline-primary{% endif %}">按胜场排序</a>
-      <a href="{{ url_for('ranking.show_ranking', sort_by='win_rate') }}" class="btn btn-sm {% if sort_by == 'win_rate' %}btn-primary{% else %}btn-outline-primary{% endif %}">按胜率排序</a>
-    </div> -->
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2 class="mb-0">玩家排行榜</h2>
+        </div>
+        <!-- 标签页导航 -->
+        <ul class="nav nav-tabs mb-3">
+            <li class="nav-item">
+                <a class="nav-link {% if current_ranking_id == 0 %}active{% endif %}"
+                   href="{{ url_for('ranking.show_ranking', ranking_id=0) }}">主排行榜</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if current_ranking_id == 1 %}active{% endif %}"
+                   href="{{ url_for('ranking.show_ranking', ranking_id=1) }}">天梯赛S1 (示例)</a>
+            </li>
+            {# 在这里可以动态添加更多排行榜的标签页 #}
+            {# 例如，如果有一个排行榜列表传递到模板中:
+      {% for rank_info in available_rankings %}
+      <li class="nav-item">
+        <a class="nav-link {% if current_ranking_id == rank_info.id %}active{% endif %}" href="{{ url_for('ranking.show_ranking', ranking_id=rank_info.id) }}">{{ rank_info.name }}</a>
+      </li>
+      {% endfor %}
+      #}
+        </ul>
         <div class="card shadow-sm">
             <div class="card-body p-0">
                 <div class="table-responsive">


### PR DESCRIPTION
- 修改 GameStats 模型，使其与 User 变为一对多关系，并增加 ranking_id 字段以区分不同榜单。
- 为 Battle 模型增加 ranking_id 字段，使每场对战与特定榜单关联。
- 更新分数计算逻辑（process_battle_results_and_update_stats）：根据 Battle 的 ranking_id 获取并更新对应 GameStats 条目中的分数。
- 确保新用户默认拥有 ranking_id=0 的 GameStats 记录。
- 调整 create_battle 逻辑，以处理 ranking_id 并从对应榜单获取初始ELO。
- 修改排行榜显示及API，支持按 ranking_id 筛选。