### PR TITLE
装饰器实现

### DIFF
--- a/game/battle_manager.py
+++ b/game/battle_manager.py
@@ -15,8 +15,12 @@ from typing import Dict, Any, Optional, List, Tuple
 
 # 导入裁判和观察者
 from .referee import AvalonReferee  # 确保导入正确
-from .observer import Observer  # 确保导入正确
+from .observer import Observer # 确保导入正确
 from services.battle_service import BattleService  # 假设 BattleService 在 services 包中
+
+# 导入装饰器
+from .decorator import DebugDecorator, settings
+
 
 
 # 配置日志 (BattleManager 自身的日志)
@@ -250,6 +254,14 @@ class BattleManager:
         返回：是否成功加入队列
         """
         battle_observer = Observer(battle_id)
+
+        # 装饰器
+        if settings["observer.Observer"] == 1:
+            # 装饰实例
+            dec = DebugDecorator(battle_id)
+            battle_observer = dec.decorate_instance(battle_observer)
+
+
         self.battle_observers[battle_id] = battle_observer
 
         self.battle_observers[battle_id].make_snapshot(
@@ -395,6 +407,13 @@ class BattleManager:
                 observer=battle_observer,  # 观察者对象
                 battle_service=self.battle_service,  # 服务对象
             )
+
+            # 装饰器
+        if settings["referee.AvalonReferee"] == 1:
+            # 装饰实例
+            dec = DebugDecorator(battle_id)
+            referee = dec.decorate_instance(referee)
+
 
             # 4. 运行游戏
             result_data = referee.run_game()

--- a/game/decorator.py
+++ b/game/decorator.py
@@ -1,0 +1,111 @@
+import threading
+import os
+from datetime import datetime
+from inspect import getfile
+
+
+
+settings = {
+    "referee.AvalonReferee": 1,
+    "observer.Observer": 1,
+    "avalon_game_helper.GameHelper": 1,
+    "1": 1,
+    "2": 1,
+    "3": 1,
+    "4": 1,
+    "5": 1,
+    "6": 1,
+    "7": 1,
+    "8": 1,
+    "9": 1,
+    "10": 1,
+    "11": 1,
+    "12": 1
+}
+
+
+
+
+
+
+class DebugDecorator:
+    def __init__(self, battle_id):
+        # 获取当前脚本的绝对路径
+        current_file = os.path.abspath(__file__) 
+        filename = 'decorator_out.log'  # 日志文件名
+        
+        # 增强路径安全性检测
+        current_file = os.path.abspath(getfile(self.__class__))  # 准确获取类定义文件路径
+        target_dir = os.path.abspath(  # 构造绝对路径
+            os.path.join(
+                os.path.dirname(current_file),
+                '..', 
+                'data',
+                str(battle_id) 
+            )
+        )
+        
+        # 路径验证与创建
+        self.filename = os.path.join(target_dir, filename)
+        os.makedirs(target_dir, exist_ok=True)  # 自动创建所有缺失目录
+
+        print(f"✅ 目标目录确认：{os.path.abspath(target_dir)}")
+        print(f"📁 日志文件将保存至：{os.path.abspath(self.filename)}")
+
+        self.local_data = threading.local()
+        self.lock = threading.RLock()
+
+    def _log(self, event_type, func_name, stack, args):
+        """日志处理方法"""
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        thread_id = threading.get_ident()
+        
+        # 控制台输出(有颜色)
+        console_msg = (
+            f"[{timestamp}] [Thread-{thread_id}] "
+            f"[{event_type}] 函数名: \033[34m{func_name}\033[0m\n"
+            f"      嵌套层级: {len(stack)}\n"
+            f"      调用关系: \033[33m{' → '.join(stack)}\033[0m\n"
+            f"      接收参数: args={args}\n"
+        )
+        print(console_msg)
+
+        # 文件输出（无颜色）
+        file_msg = (
+            f"[{timestamp}] [Thread-{thread_id}] [{event_type}] "
+            f"函数名: {func_name} | 层级: {len(stack)} | "
+            f"调用链: {'→'.join(stack)} | 参数: args={args}\n"
+        )
+        
+        with self.lock:
+            with open(self.filename, 'a', encoding='utf-8') as f:
+                f.write(file_msg)
+
+    def __call__(self, func):
+        def wrapper(*args):
+            if not hasattr(self.local_data, 'stack'):
+                self.local_data.stack = []
+            
+            self.local_data.stack.append(func.__name__)
+            current_stack = self.local_data.stack.copy()
+            
+            self._log("Call", func.__name__, current_stack, args)
+
+            try:
+                result = func(*args)
+            finally:
+                self.local_data.stack.pop()
+                self._log("Done", func.__name__, current_stack, args)
+
+            return result
+        return wrapper
+
+
+    def decorate_instance(self, instance):
+        """动态装饰一个实例的所有方法"""
+        for name in dir(instance):
+            if not name.startswith('_'):  # 跳过私有方法
+                attr = getattr(instance, name)
+                if callable(attr):
+                    setattr(instance, name, self(attr))  # 用__call__装饰方法
+        return instance

--- a/game/referee.py
+++ b/game/referee.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 import logging
 import importlib.util
 from datetime import datetime
+from .decorator import DebugDecorator, settings
 from .observer import Observer
 from .avalon_game_helper import INIT_PRIVA_LOG_DICT
 from .restrictor import RESTRICTED_BUILTINS
@@ -221,6 +222,14 @@ class AvalonReferee:
 
         # 为这个referee创建一个专用的GameHelper实例
         self.game_helper = GameHelper(data_dir=self.data_dir)
+
+        # 装饰器
+        if settings["observer.Observer"] == 1:
+            # 装饰实例
+            dec = DebugDecorator(self.battle_id)
+            self.game_helper = dec.decorate_instance(self.game_helper)
+
+
         self.game_helper.game_session_id = self.game_id  # 直接设置game_id
 
         # 创建数据目录


### PR DESCRIPTION
## 装饰器实现

改动referee，battle_manager，增加decorator
现在可以对每个实例进行自动装饰，使得可在终端（设置为彩色）可读性较强地输出函数调用情况，也会自动把装饰器输出内容保存到/data/id/decorator_out.log中
输出内容包括：
/[时间/]/[线程/]/[CALL/DONE]
调用函数名，函数嵌套层级，函数调用逻辑链，函数接受的原始输入。


## PR 类型

- [ ] Bug 修复 (Bug fix)
- [x] 新功能 (New feature)
- [ ] 代码样式更新 (Code style update) (格式化、缺少分号等，不影响代码逻辑)
- [ ] 重构 (Refactoring) (既不是新增功能，也不是修复 bug)
- [ ] 构建工具相关 (Build related changes)
- [ ] CI 配置相关 (CI configuration changes)
- [ ] 文档更新 (Documentation)
- [ ] 性能优化 (Performance improvement)
- [x] 测试相关 (Test related)
- [ ] 其他 (Other): 

## PR 目的与背景

帮助测试，了解运行过程中函数调用情况，输出更多信息





## 开关以及扩展

在/game/decorator.py中，有字典settings保存设置，启用显示某个类的装饰可直接将字典中对应的值改成1

![4eb6db9affe2e724ecc95e00fadc42a](https://github.com/user-attachments/assets/935e41d3-727c-44bb-a829-56024727e892)
![8386c322d349eaa5e7b19f0c4a1c9ff](https://github.com/user-attachments/assets/055e26b4-238a-43b3-829d-607573e08c21)
![CFMKLQSOZW 0S7NZYSW58Q6](https://github.com/user-attachments/assets/c53828ef-0705-4032-bccc-896bc439633d)




## 效果图

输出到的log文件内

![8386c322d349eaa5e7b19f0c4a1c9ff](C:\Users\26099\Desktop\8386c322d349eaa5e7b19f0c4a1c9ff.jpg)

终端显示

![4eb6db9affe2e724ecc95e00fadc42a](C:\Users\26099\Desktop\4eb6db9affe2e724ecc95e00fadc42a.jpg)